### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -10,6 +10,10 @@ on:
         description: 'Script to run after audit fix'
         required: false
         default: 'npm run all'
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: read
@@ -24,3 +28,4 @@ jobs:
     with:
       tag: "${{ github.event.inputs.tag }}"
       script: "${{ github.event.inputs.script }}"
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit-package.yml
+++ b/.github/workflows/audit-package.yml
@@ -14,7 +14,11 @@ on:
         description: 'Script to run after audit fix'
         required: false
         default: 'npm run all'
-  
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
+
   schedule:
     - cron: '0 0 * * 1'
 
@@ -25,6 +29,7 @@ jobs:
       force: ${{ inputs.force || false }}
       base_branch: ${{ inputs.base_branch || 'main' }}
       script: ${{ inputs.script || 'npm run all' }}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -15,6 +15,10 @@ on:
         description: "Run mode: cherry-pick or verify"
         required: false
         default: "cherry-pick"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
   pull_request:
     types: [labeled, opened, synchronize]
 
@@ -34,4 +38,5 @@ jobs:
       base_branch: ${{ inputs.base_branch }}
       script: ${{ inputs.script || 'npm run all' }}
       mode: ${{ github.event_name == 'pull_request' && 'verify' || inputs.mode }}
+      node_version: "${{ inputs.node_version || '24' }}"
   

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Test Reporter
 
 This [Github Action](https://github.com/features/actions) displays test results from popular testing frameworks directly in GitHub.

--- a/dist/index.js
+++ b/dist/index.js
@@ -53712,6 +53712,8 @@ __nccwpck_require__.d(common_utils_namespaceObject, {
   origin: () => (origin)
 });
 
+// EXTERNAL MODULE: external "fs"
+var external_fs_ = __nccwpck_require__(9896);
 // EXTERNAL MODULE: external "os"
 var external_os_ = __nccwpck_require__(857);
 ;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/utils.js
@@ -53844,8 +53846,6 @@ function escapeProperty(s) {
 //# sourceMappingURL=command.js.map
 // EXTERNAL MODULE: external "crypto"
 var external_crypto_ = __nccwpck_require__(6982);
-// EXTERNAL MODULE: external "fs"
-var external_fs_ = __nccwpck_require__(9896);
 ;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/file-command.js
 // For internal use, subject to change.
 // We use any as a valid input type
@@ -69882,6 +69882,7 @@ const {
 
 
 
+
 async function main() {
     try {
         const testReporter = new TestReporter();
@@ -70116,18 +70117,38 @@ class TestReporter {
 }
 main();
 async function validateSubscription() {
-    const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    let repoPrivate;
+    if (eventPath && external_fs_.existsSync(eventPath)) {
+        const eventData = JSON.parse(external_fs_.readFileSync(eventPath, 'utf8'));
+        repoPrivate = eventData?.repository?.private;
+    }
+    const upstream = 'dorny/test-reporter';
+    const action = process.env.GITHUB_ACTION_REPOSITORY;
+    const docsUrl = 'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions';
+    info('');
+    info('\u001b[1;36mStepSecurity Maintained Action\u001b[0m');
+    info(`Secure drop-in replacement for ${upstream}`);
+    if (repoPrivate === false)
+        info('\u001b[32m\u2713 Free for public repositories\u001b[0m');
+    info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`);
+    info('');
+    if (repoPrivate === false)
+        return;
+    const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+    const body = { action: action || '' };
+    if (serverUrl !== 'https://github.com')
+        body.ghes_server = serverUrl;
     try {
-        await lib_axios.get(API_URL, { timeout: 3000 });
+        await lib_axios.post(`https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`, body, { timeout: 3000 });
     }
     catch (error) {
         if (axios_isAxiosError(error) && error.response?.status === 403) {
-            core_error('Subscription is not valid. Reach out to support@stepsecurity.io');
+            core_error(`\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`);
+            core_error(`\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`);
             process.exit(1);
         }
-        else {
-            info('Timeout or API not reachable. Continuing to next step.');
-        }
+        info('Timeout or API not reachable. Continuing to next step.');
     }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {GitHub} from '@actions/github/lib/utils'
@@ -299,16 +300,48 @@ class TestReporter {
 main()
 
 async function validateSubscription(): Promise<void> {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  let repoPrivate: boolean | undefined
 
+  if (eventPath && fs.existsSync(eventPath)) {
+    const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'))
+    repoPrivate = eventData?.repository?.private
+  }
+
+  const upstream = 'dorny/test-reporter'
+  const action = process.env.GITHUB_ACTION_REPOSITORY
+  const docsUrl =
+    'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions'
+
+  core.info('')
+  core.info('\u001b[1;36mStepSecurity Maintained Action\u001b[0m')
+  core.info(`Secure drop-in replacement for ${upstream}`)
+  if (repoPrivate === false)
+    core.info('\u001b[32m\u2713 Free for public repositories\u001b[0m')
+  core.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`)
+  core.info('')
+
+  if (repoPrivate === false) return
+
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+  const body: Record<string, string> = {action: action || ''}
+  if (serverUrl !== 'https://github.com') body.ghes_server = serverUrl
   try {
-    await axios.get(API_URL, {timeout: 3000})
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      {timeout: 3000}
+    )
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 403) {
-      core.error('Subscription is not valid. Reach out to support@stepsecurity.io')
+      core.error(
+        `\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`
+      )
+      core.error(
+        `\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`
+      )
       process.exit(1)
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.')
     }
+    core.info('Timeout or API not reachable. Continuing to next step.')
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -310,14 +310,12 @@ async function validateSubscription(): Promise<void> {
 
   const upstream = 'dorny/test-reporter'
   const action = process.env.GITHUB_ACTION_REPOSITORY
-  const docsUrl =
-    'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions'
+  const docsUrl = 'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions'
 
   core.info('')
   core.info('\u001b[1;36mStepSecurity Maintained Action\u001b[0m')
   core.info(`Secure drop-in replacement for ${upstream}`)
-  if (repoPrivate === false)
-    core.info('\u001b[32m\u2713 Free for public repositories\u001b[0m')
+  if (repoPrivate === false) core.info('\u001b[32m\u2713 Free for public repositories\u001b[0m')
   core.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`)
   core.info('')
 
@@ -334,12 +332,8 @@ async function validateSubscription(): Promise<void> {
     )
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 403) {
-      core.error(
-        `\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`
-      )
-      core.error(
-        `\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`
-      )
+      core.error(`\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`)
+      core.error(`\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`)
       process.exit(1)
     }
     core.info('Timeout or API not reachable. Continuing to next step.')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es2023"],
     "module": "nodenext",
-    "target": "es2022",
+    "target": "ES2024",
 
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260421T093146Z